### PR TITLE
Handle missing members and filter bots in member select

### DIFF
--- a/src/components/select.py
+++ b/src/components/select.py
@@ -1,10 +1,15 @@
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, TypeVar
+
 import discord
 
-from data_interface import DataInterface
-from db_manager import db
 from models.context_model import CommandContext
 from models.model import Template
 from models.state_model import AmidakujiState
+
+if TYPE_CHECKING:
+    from data_interface import DataInterface
+    from db_manager import DBManager
 
 
 class TemplateSelect(discord.ui.Select):
@@ -19,6 +24,9 @@ class TemplateSelect(discord.ui.Select):
         self.context = context
 
     async def callback(self, interaction: discord.Interaction):
+        from db_manager import db
+        from data_interface import DataInterface
+
         # 取得した値を元にテンプレートを取得
         selected_template_title = self.values[0]
         current_user = db.get_user(interaction.user.id)
@@ -37,6 +45,21 @@ class TemplateSelect(discord.ui.Select):
         await interface.forward()
 
 
+T = TypeVar("T")
+
+
+def remove_bots(users: Iterable[T]) -> list[T]:
+    """Return users without bot accounts.
+
+    Both ``discord.User`` and ``discord.Member`` expose a ``bot`` attribute, but
+    it may be missing for custom implementations in tests.  ``getattr`` with a
+    default ensures that we treat objects without the attribute as non-bot
+    users.
+    """
+
+    return [user for user in users if not getattr(user, "bot", False)]
+
+
 class MemberSelect(discord.ui.UserSelect):
     def __init__(self, context: CommandContext):
         super().__init__(
@@ -47,16 +70,25 @@ class MemberSelect(discord.ui.UserSelect):
         self.context = context
 
     async def callback(self, interaction: discord.Interaction):
+        from data_interface import DataInterface
+
         # Memberの可能性があるので、Userに変換(APIの仕様上、DM内ならUser, サーバー内ならMemberに統一されている)
-        result = []
+        result: list[discord.User] = []
         for user in self.values:
             if isinstance(user, discord.User):
                 result.append(user)
             elif isinstance(user, discord.Member):
-                result.append(self.context.interaction.client.get_user(user.id))
+                resolved_user = interaction.client.get_user(user.id)
+                if resolved_user is None:
+                    try:
+                        resolved_user = await interaction.client.fetch_user(user.id)
+                    except discord.DiscordException:
+                        resolved_user = None
+                if resolved_user is not None:
+                    result.append(resolved_user)
 
         # botを除外
-        result = [user for user in result if user is not user.bot]
+        result = remove_bots(result)
 
         self.context.update_context(
             state=AmidakujiState.MEMBER_SELECTED,

--- a/tests/test_member_select.py
+++ b/tests/test_member_select.py
@@ -1,0 +1,13 @@
+from types import SimpleNamespace
+
+from components.select import remove_bots
+
+
+def test_remove_bots_filters_out_bot_accounts():
+    human = SimpleNamespace(name="human", bot=False)
+    bot = SimpleNamespace(name="bot", bot=True)
+    unknown = SimpleNamespace(name="unknown")
+
+    filtered = remove_bots([human, bot, unknown])
+
+    assert filtered == [human, unknown]


### PR DESCRIPTION
## Summary
- guard MemberSelect against missing cached users by fetching or skipping entries
- share a reusable helper that filters out bot accounts via the `bot` attribute
- add a unit test to ensure mixed user lists lose their bot members

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9fee1ea94832a866dc978637e6698