### PR TITLE
Improve embed avatar handling and add tests

### DIFF
--- a/src/data_process.py
+++ b/src/data_process.py
@@ -27,26 +27,32 @@ def create_pair_from_list(users: list[discord.User], groupes: list[str]) -> Pair
 def create_embeds_from_pairs(
     pairs: PairList, mode: ResultEmbedMode = ResultEmbedMode.COMPACT
 ) -> list[discord.Embed]:
-    embeds = []
+    embeds: list[discord.Embed] = []
 
     pair_list = pairs.pairs
+    if isinstance(mode, ResultEmbedMode):
+        normalized_mode = mode.value
+    else:
+        normalized_mode = str(mode).lower()
 
-    if mode == "compact":
+    if normalized_mode == ResultEmbedMode.COMPACT.value:
         for pair in pair_list:
             embed = discord.Embed()
+            avatar_asset = getattr(pair.user, "display_avatar", None)
             embed.set_author(
-                icon_url=pair.user.avatar.url,
+                icon_url=getattr(avatar_asset, "url", None),
                 name=f" ┃ {pair.choice}",
             )
             embeds.append(embed)
         return embeds
 
-    elif mode == "detailed":
+    elif normalized_mode == ResultEmbedMode.DETAILED.value:
         for pair in pair_list:
             embed = discord.Embed()
             embed.title = f"> {pair.choice}"
+            avatar_asset = getattr(pair.user, "display_avatar", None)
             embed.set_author(
-                icon_url=pair.user.avatar.url,
+                icon_url=getattr(avatar_asset, "url", None),
                 name=pair.user.display_name,
             )
             embeds.append(embed)

--- a/tests/test_data_process.py
+++ b/tests/test_data_process.py
@@ -47,7 +47,7 @@ def test_create_embeds_detailed_mode_handles_missing_custom_avatar() -> None:
     )
     pair_list = PairList(pairs=[Pair(user=user, choice="Jungle")])
 
-    embeds = create_embeds_from_pairs(pair_list, mode="DETAILED")
+    embeds = create_embeds_from_pairs(pair_list, mode=ResultEmbedMode.DETAILED)
 
     assert len(embeds) == 1
     embed = embeds[0]

--- a/tests/test_data_process.py
+++ b/tests/test_data_process.py
@@ -1,0 +1,57 @@
+from data_process import create_embeds_from_pairs
+from models.model import Pair, PairList, ResultEmbedMode
+
+
+class DummyAsset:
+    def __init__(self, url: str | None):
+        self.url = url
+
+
+class DummyUser:
+    def __init__(
+        self,
+        display_name: str,
+        *,
+        custom_avatar_url: str | None,
+        fallback_avatar_url: str,
+    ) -> None:
+        self.display_name = display_name
+        self.display_avatar = DummyAsset(custom_avatar_url or fallback_avatar_url)
+        # ``avatar`` is intentionally set to None when a custom avatar is missing
+        self.avatar = (
+            DummyAsset(custom_avatar_url) if custom_avatar_url is not None else None
+        )
+
+
+def test_create_embeds_compact_mode_uses_display_avatar() -> None:
+    user = DummyUser(
+        "Custom Avatar User",
+        custom_avatar_url="https://example.com/custom.png",
+        fallback_avatar_url="https://example.com/default.png",
+    )
+    pair_list = PairList(pairs=[Pair(user=user, choice="Top Lane")])
+
+    embeds = create_embeds_from_pairs(pair_list, mode=ResultEmbedMode.COMPACT)
+
+    assert len(embeds) == 1
+    embed = embeds[0]
+    assert embed.author.icon_url == "https://example.com/custom.png"
+    assert embed.author.name == " ┃ Top Lane"
+
+
+def test_create_embeds_detailed_mode_handles_missing_custom_avatar() -> None:
+    user = DummyUser(
+        "Default Avatar User",
+        custom_avatar_url=None,
+        fallback_avatar_url="https://example.com/default.png",
+    )
+    pair_list = PairList(pairs=[Pair(user=user, choice="Jungle")])
+
+    embeds = create_embeds_from_pairs(pair_list, mode="DETAILED")
+
+    assert len(embeds) == 1
+    embed = embeds[0]
+    assert embed.title == "> Jungle"
+    assert embed.author.icon_url == "https://example.com/default.png"
+    assert embed.author.name == "Default Avatar User"
+


### PR DESCRIPTION
## Summary
- normalize embed mode handling to accept enum members or strings
- fall back to `display_avatar` when building embeds to tolerate missing custom avatars
- add unit tests covering compact and detailed embed modes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca738babc0832a9e199ae47b27c29a