### PR TITLE
Refactor embed creation helpers

### DIFF
--- a/src/data_process.py
+++ b/src/data_process.py
@@ -24,41 +24,48 @@ def create_pair_from_list(users: list[discord.User], groupes: list[str]) -> Pair
 
 
 # TODO: 将来的に、utils.pyで定義されているlolの絵文字を使って、レーンごとに絵文字も併せて表示するように変更する
+def _normalize_mode(mode: ResultEmbedMode | str) -> str:
+    if isinstance(mode, ResultEmbedMode):
+        return mode.value
+    return str(mode).lower()
+
+
+def _build_compact_embed(pair: Pair) -> discord.Embed:
+    embed = discord.Embed()
+    avatar_asset = getattr(pair.user, "display_avatar", None)
+    embed.set_author(
+        icon_url=getattr(avatar_asset, "url", None),
+        name=f" ┃ {pair.choice}",
+    )
+    return embed
+
+
+def _build_detailed_embed(pair: Pair) -> discord.Embed:
+    embed = discord.Embed()
+    embed.title = f"> {pair.choice}"
+    avatar_asset = getattr(pair.user, "display_avatar", None)
+    embed.set_author(
+        icon_url=getattr(avatar_asset, "url", None),
+        name=pair.user.display_name,
+    )
+    return embed
+
+
 def create_embeds_from_pairs(
     pairs: PairList, mode: ResultEmbedMode = ResultEmbedMode.COMPACT
 ) -> list[discord.Embed]:
-    embeds: list[discord.Embed] = []
-
     pair_list = pairs.pairs
-    if isinstance(mode, ResultEmbedMode):
-        normalized_mode = mode.value
-    else:
-        normalized_mode = str(mode).lower()
+    normalized_mode = _normalize_mode(mode)
+    builder_map = {
+        ResultEmbedMode.COMPACT.value: _build_compact_embed,
+        ResultEmbedMode.DETAILED.value: _build_detailed_embed,
+    }
 
-    if normalized_mode == ResultEmbedMode.COMPACT.value:
-        for pair in pair_list:
-            embed = discord.Embed()
-            avatar_asset = getattr(pair.user, "display_avatar", None)
-            embed.set_author(
-                icon_url=getattr(avatar_asset, "url", None),
-                name=f" ┃ {pair.choice}",
-            )
-            embeds.append(embed)
-        return embeds
+    builder = builder_map.get(normalized_mode)
+    if builder is None:
+        return []
 
-    elif normalized_mode == ResultEmbedMode.DETAILED.value:
-        for pair in pair_list:
-            embed = discord.Embed()
-            embed.title = f"> {pair.choice}"
-            avatar_asset = getattr(pair.user, "display_avatar", None)
-            embed.set_author(
-                icon_url=getattr(avatar_asset, "url", None),
-                name=pair.user.display_name,
-            )
-            embeds.append(embed)
-        return embeds
-
-    return embeds
+    return [builder(pair) for pair in pair_list]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extract helper functions to build compact and detailed embed representations
- introduce a normalization helper for result embed modes
- simplify `create_embeds_from_pairs` with a builder map

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb494f8498832ab63539972fbac221