### PR TITLE
Fix default template initialization fallback

### DIFF
--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -174,8 +174,15 @@ class DBManager(metaclass=utils.Singleton):
     def get_default_templates(self) -> list[Template]:
         info_repository = self._get_info_repository()
         templates = info_repository.read_document("default_templates")
-        templates = templates["default_templates"]  # list
-        return [self._dict_to_template(t) for t in templates]
+        if not isinstance(templates, dict) or "default_templates" not in templates:
+            self._init_default_templates()
+            templates = info_repository.read_document("default_templates")
+
+        template_items = templates.get("default_templates") if isinstance(templates, dict) else None
+        if not isinstance(template_items, list):
+            raise ValueError("Invalid default template data")
+
+        return [self._dict_to_template(t) for t in template_items]
 
     def toggle_embed_mode(self) -> None:
         info_repository = self._get_info_repository()

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -24,3 +24,24 @@ def test_get_embed_mode_initializes_missing_document():
     mock_info_repository.create_document.assert_called_once_with(
         "embed_mode", {"embed_mode": "compact"}
     )
+
+
+def test_get_default_templates_initializes_when_missing_document():
+    utils.Singleton._instances.pop(DBManager, None)
+    manager = DBManager.get_instance()
+
+    mock_info_repository = MagicMock()
+    # First call returns None to simulate missing document, second call returns initialized data
+    mock_info_repository.read_document.side_effect = [None, {"default_templates": []}]
+
+    manager.info_repository = mock_info_repository
+    manager.user_repository = object()
+    manager.db = object()
+
+    try:
+        templates = manager.get_default_templates()
+    finally:
+        utils.Singleton._instances.pop(DBManager, None)
+
+    assert templates == []
+    mock_info_repository.create_document.assert_called_once()


### PR DESCRIPTION
## Summary
- ensure default templates are initialized when the Firestore document is missing or malformed
- raise an explicit error if the default template payload lacks the expected list
- add a regression test covering the default template initialization path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb65d27f80832a97dac81f693dd9e2