### PR TITLE
Add comprehensive tests for flow control and context

### DIFF
--- a/tests/test_command_context.py
+++ b/tests/test_command_context.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import MagicMock
+
+import discord
+
+from models.context_model import CommandContext
+from models.state_model import AmidakujiState
+
+
+@pytest.fixture
+def mock_interaction():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock()
+    return interaction
+
+
+def test_command_context_updates_history_and_result(mock_interaction):
+    context = CommandContext(interaction=mock_interaction, state=AmidakujiState.COMMAND_EXECUTED)
+
+    context.result = mock_interaction
+
+    assert context.result is mock_interaction
+    assert context.history[AmidakujiState.COMMAND_EXECUTED] is mock_interaction
+
+
+def test_command_context_rejects_invalid_result_type(mock_interaction):
+    context = CommandContext(interaction=mock_interaction, state=AmidakujiState.TEMPLATE_TITLE_ENTERED)
+
+    with pytest.raises(TypeError):
+        context.result = 42
+
+
+def test_update_context_replaces_interaction(mock_interaction):
+    context = CommandContext(interaction=mock_interaction, state=AmidakujiState.COMMAND_EXECUTED)
+    context.result = mock_interaction
+
+    new_interaction = MagicMock(spec=discord.Interaction)
+    new_interaction.user = MagicMock()
+
+    context.update_context(
+        state=AmidakujiState.MODE_CREATE_NEW,
+        result=new_interaction,
+        interaction=new_interaction,
+    )
+
+    assert context.interaction is new_interaction
+    assert context.state is AmidakujiState.MODE_CREATE_NEW
+    assert context.result is new_interaction
+    assert context.history[AmidakujiState.MODE_CREATE_NEW] is new_interaction

--- a/tests/test_flow_actions.py
+++ b/tests/test_flow_actions.py
@@ -1,0 +1,148 @@
+import pytest
+from unittest.mock import MagicMock
+
+import discord
+
+from flow.actions import (
+    DeferResponseAction,
+    SendMessageAction,
+    SendViewAction,
+    ShowModalAction,
+)
+from models.context_model import CommandContext
+from models.state_model import AmidakujiState
+
+
+class DummyResponse:
+    def __init__(self, *, done: bool = False):
+        self._done = done
+        self.sent_messages: list[dict] = []
+        self.sent_modal = None
+        self.deferred = None
+
+    def is_done(self) -> bool:
+        return self._done
+
+    async def send_message(self, **payload):
+        self.sent_messages.append(payload)
+
+    async def send_modal(self, modal):
+        self.sent_modal = modal
+
+    async def defer(self, *, ephemeral: bool = True):
+        self.deferred = ephemeral
+
+
+class DummyFollowup:
+    def __init__(self):
+        self.sent_messages: list[dict] = []
+
+    async def send(self, **payload):
+        self.sent_messages.append(payload)
+
+
+@pytest.fixture
+def context():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = DummyResponse(done=False)
+    interaction.followup = DummyFollowup()
+    interaction.user = MagicMock()
+
+    context = CommandContext(
+        interaction=interaction,
+        state=AmidakujiState.COMMAND_EXECUTED,
+    )
+    context.result = interaction
+    return context
+
+
+@pytest.mark.asyncio
+async def test_send_view_action_uses_initial_response(context):
+    view = discord.ui.View()
+
+    action = SendViewAction(view=view, ephemeral=False)
+    await action.execute(context)
+
+    assert context.interaction.response.sent_messages == [
+        {"view": view, "ephemeral": False}
+    ]
+    assert context.interaction.followup.sent_messages == []
+
+
+@pytest.mark.asyncio
+async def test_send_view_action_forces_followup(context):
+    view = discord.ui.View()
+
+    action = SendViewAction(view=view, followup=True)
+    await action.execute(context)
+
+    assert context.interaction.followup.sent_messages == [
+        {"view": view, "ephemeral": True}
+    ]
+    assert context.interaction.response.sent_messages == []
+
+
+@pytest.mark.asyncio
+async def test_send_message_action_includes_embeds_and_content(context):
+    embed = discord.Embed(title="Hello")
+    embeds = [discord.Embed(title="World")]
+
+    action = SendMessageAction(
+        content="greetings",
+        embed=embed,
+        embeds=embeds,
+        ephemeral=False,
+        followup=False,
+    )
+    await action.execute(context)
+
+    assert context.interaction.response.sent_messages == [
+        {
+            "content": "greetings",
+            "embed": embed,
+            "embeds": embeds,
+            "ephemeral": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_message_action_defaults_to_followup_when_responded(context):
+    context.interaction.response = DummyResponse(done=True)
+    context.interaction.followup = DummyFollowup()
+
+    action = SendMessageAction(content="done")
+    await action.execute(context)
+
+    assert context.interaction.followup.sent_messages == [
+        {"content": "done", "ephemeral": True}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_show_modal_action_invokes_send_modal(context):
+    modal = discord.ui.Modal(title="Modal")
+    action = ShowModalAction(modal=modal)
+
+    await action.execute(context)
+
+    assert context.interaction.response.sent_modal is modal
+
+
+@pytest.mark.asyncio
+async def test_defer_response_action_skips_when_already_done(context):
+    context.interaction.response = DummyResponse(done=True)
+    action = DeferResponseAction(ephemeral=False)
+
+    await action.execute(context)
+
+    assert context.interaction.response.deferred is None
+
+
+@pytest.mark.asyncio
+async def test_defer_response_action_defers_when_pending(context):
+    action = DeferResponseAction(ephemeral=False)
+
+    await action.execute(context)
+
+    assert context.interaction.response.deferred is False

--- a/tests/test_flow_controller.py
+++ b/tests/test_flow_controller.py
@@ -1,0 +1,97 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+
+from flow.actions import FlowAction
+from flow.handlers import BaseStateHandler
+from data_interface import FlowController
+from models.context_model import CommandContext
+from models.state_model import AmidakujiState
+
+
+class DummyAction:
+    def __init__(self):
+        self.executed = False
+
+    async def execute(self, context: CommandContext) -> None:
+        self.executed = True
+        context.update_context(
+            state=AmidakujiState.CANCELLED,
+            result=context.interaction,
+            interaction=context.interaction,
+        )
+
+
+class DummyHandler(BaseStateHandler):
+    def __init__(self, action: FlowAction):
+        self._action = action
+        self.called_with: tuple[CommandContext, object] | None = None
+
+    async def handle(self, context: CommandContext, services):
+        self.called_with = (context, services)
+        return self._action
+
+
+@pytest.fixture
+def controller():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock()
+    interaction.response = MagicMock()
+    interaction.followup = MagicMock()
+
+    context = CommandContext(
+        interaction=interaction,
+        state=AmidakujiState.COMMAND_EXECUTED,
+    )
+    context.result = interaction
+
+    services = SimpleNamespace()
+    controller = FlowController(context=context, services=services)
+    return controller, context, services
+
+
+@pytest.mark.asyncio
+async def test_dispatch_runs_handler_and_updates_context(controller):
+    controller, context, services = controller
+    action = DummyAction()
+    handler = DummyHandler(action)
+
+    controller._handlers[AmidakujiState.MODE_CREATE_NEW] = handler
+
+    await controller.dispatch(
+        AmidakujiState.MODE_CREATE_NEW,
+        context.interaction,
+        context.interaction,
+    )
+
+    assert action.executed is True
+    assert handler.called_with == (context, services)
+    assert context.state is AmidakujiState.CANCELLED
+    assert context.services is services
+
+
+@pytest.mark.asyncio
+async def test_execute_action_handles_sequence(controller):
+    controller, context, _ = controller
+
+    action1 = SimpleNamespace(execute=AsyncMock())
+    action2 = SimpleNamespace(execute=AsyncMock())
+
+    await controller._execute_action([action1, action2])
+
+    action1.execute.assert_awaited_once_with(context)
+    action2.execute.assert_awaited_once_with(context)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_raises_for_unknown_state(controller):
+    controller, context, _ = controller
+
+    with pytest.raises(ValueError):
+        await controller.dispatch(
+            AmidakujiState.COMMAND_EXECUTED,
+            context.interaction,
+            context.interaction,
+        )

--- a/tests/test_flow_handlers.py
+++ b/tests/test_flow_handlers.py
@@ -1,0 +1,185 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import discord
+
+import data_process
+from flow.actions import DeferResponseAction, SendMessageAction, SendViewAction
+from flow.handlers import (
+    MemberSelectedHandler,
+    TemplateCreatedHandler,
+    TemplateDeterminedHandler,
+    UseExistingHandler,
+    UseHistoryHandler,
+)
+from models.context_model import CommandContext
+from models.model import Template, UserInfo
+from models.state_model import AmidakujiState
+from views.view import MemberSelectView, SelectTemplateView
+
+
+@pytest.fixture
+def base_interaction():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock(id=42)
+    interaction.response = MagicMock()
+    interaction.followup = MagicMock()
+    return interaction
+
+
+@pytest.mark.asyncio
+async def test_use_existing_handler_returns_select_view(base_interaction):
+    context = CommandContext(
+        interaction=base_interaction,
+        state=AmidakujiState.MODE_USE_EXISTING,
+    )
+    context.result = base_interaction
+
+    template = Template(title="League", choices=["Top"])
+    user = UserInfo(id=42, name="Tester", custom_templates=[template])
+
+    services = SimpleNamespace(db=MagicMock())
+    services.db.get_user.return_value = user
+
+    handler = UseExistingHandler()
+    action = await handler.handle(context, services)
+
+    assert isinstance(action, SendViewAction)
+    assert isinstance(action.view, SelectTemplateView)
+    assert len(action.view.children) == 1
+
+
+@pytest.mark.asyncio
+async def test_template_created_handler_updates_context_and_saves_template(base_interaction):
+    template = Template(title="Valorant", choices=["Duelist"])
+    context = CommandContext(
+        interaction=base_interaction,
+        state=AmidakujiState.TEMPLATE_CREATED,
+    )
+    context.result = template
+
+    services = SimpleNamespace(db=MagicMock())
+
+    handler = TemplateCreatedHandler()
+    actions = await handler.handle(context, services)
+
+    assert isinstance(actions, list)
+    assert isinstance(actions[0], DeferResponseAction)
+    assert isinstance(actions[1], SendMessageAction)
+    services.db.add_custom_template.assert_called_once_with(
+        user_id=42, template=template
+    )
+    assert context.state is AmidakujiState.TEMPLATE_DETERMINED
+    assert context.result is template
+
+
+@pytest.mark.asyncio
+async def test_use_history_handler_returns_error_when_missing_history(base_interaction):
+    context = CommandContext(
+        interaction=base_interaction,
+        state=AmidakujiState.MODE_USE_HISTORY,
+    )
+    context.result = base_interaction
+
+    services = SimpleNamespace(db=MagicMock())
+    services.db.get_user.return_value = UserInfo(id=42, name="Tester")
+
+    handler = UseHistoryHandler()
+    action = await handler.handle(context, services)
+
+    assert isinstance(action, SendMessageAction)
+    assert "履歴が見つかりませんでした" in action.embed.description
+    assert context.state is AmidakujiState.MODE_USE_HISTORY
+
+
+@pytest.mark.asyncio
+async def test_use_history_handler_returns_followup_when_history_exists(base_interaction):
+    context = CommandContext(
+        interaction=base_interaction,
+        state=AmidakujiState.COMMAND_EXECUTED,
+    )
+    context.result = base_interaction
+    context.update_context(
+        state=AmidakujiState.MODE_USE_HISTORY,
+        result=base_interaction,
+        interaction=base_interaction,
+    )
+
+    template = Template(title="Saved", choices=["A", "B"])
+    user = UserInfo(id=42, name="Tester", least_template=template)
+
+    services = SimpleNamespace(db=MagicMock())
+    services.db.get_user.return_value = user
+
+    handler = UseHistoryHandler()
+    action = await handler.handle(context, services)
+
+    assert isinstance(action, SendMessageAction)
+    assert action.followup is True
+    assert action.interaction is context.history[AmidakujiState.COMMAND_EXECUTED]
+    assert context.state is AmidakujiState.TEMPLATE_DETERMINED
+    assert context.result is template
+
+
+@pytest.mark.asyncio
+async def test_template_determined_handler_returns_member_select_view(base_interaction):
+    template = Template(title="League", choices=["Top"])
+    context = CommandContext(
+        interaction=base_interaction,
+        state=AmidakujiState.TEMPLATE_DETERMINED,
+    )
+    context.result = template
+
+    services = SimpleNamespace(db=MagicMock())
+
+    handler = TemplateDeterminedHandler()
+    action = await handler.handle(context, services)
+
+    services.db.set_least_template.assert_called_once_with(42, template)
+    assert isinstance(action, SendViewAction)
+    assert isinstance(action.view, MemberSelectView)
+
+
+@pytest.mark.asyncio
+async def test_member_selected_handler_builds_embeds(monkeypatch, base_interaction):
+    selected_members = [
+        MagicMock(spec=discord.User),
+        MagicMock(spec=discord.User),
+    ]
+    template = Template(title="League", choices=["Top", "Jungle"])
+
+    context = CommandContext(
+        interaction=base_interaction,
+        state=AmidakujiState.MEMBER_SELECTED,
+    )
+    context.result = selected_members
+    context.history[AmidakujiState.TEMPLATE_DETERMINED] = template
+
+    pair_list = MagicMock()
+
+    def fake_create_pair_from_list(users, choices):
+        assert users == selected_members
+        assert choices == template.choices
+        return pair_list
+
+    embeds = [discord.Embed(title="Result")]
+
+    def fake_create_embeds_from_pairs(*, pairs, mode):
+        assert pairs is pair_list
+        assert mode == "compact"
+        return embeds
+
+    monkeypatch.setattr(data_process, "create_pair_from_list", fake_create_pair_from_list)
+    monkeypatch.setattr(data_process, "create_embeds_from_pairs", fake_create_embeds_from_pairs)
+
+    services = SimpleNamespace(db=MagicMock())
+    services.db.get_embed_mode.return_value = "compact"
+
+    handler = MemberSelectedHandler()
+    action = await handler.handle(context, services)
+
+    services.db.get_embed_mode.assert_called_once()
+    assert isinstance(action, SendMessageAction)
+    assert action.embeds is embeds
+    assert action.ephemeral is False


### PR DESCRIPTION
## Summary
- add unit tests for CommandContext type validation and updates
- add coverage for flow actions and controller dispatch logic
- validate major flow handlers including template workflows and member selection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb8f88ced0832a8ff7c8c29c7f282b