### PR TITLE
Add draw history tracking and fairness adjustments

### DIFF
--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -85,7 +85,7 @@ class HistoryRepository:
         template_title: str | None = None,
         limit: int = 10,
         since: datetime | None = None,
-    ) -> Iterable[dict] | None:
+    ) -> list[dict]:
         try:
             query = self.ref.where("guild_id", "==", guild_id)
             if template_title is not None:

--- a/src/flow/handlers.py
+++ b/src/flow/handlers.py
@@ -16,7 +16,7 @@ from flow.actions import (
     ShowModalAction,
 )
 from models.context_model import CommandContext
-from models.model import Template
+from models.model import AssignmentHistory, PairList, SelectionMode, Template
 from models.state_model import AmidakujiState
 from views.view import (
     ApplyOptionsView,
@@ -249,6 +249,86 @@ class TemplateDeterminedHandler(BaseStateHandler):
 
 
 class MemberSelectedHandler(BaseStateHandler):
+    HISTORY_LOOKBACK = 10
+    CONSECUTIVE_THRESHOLD = 3
+
+    @staticmethod
+    def _normalize_selection_mode(mode: str | SelectionMode) -> SelectionMode:
+        if isinstance(mode, SelectionMode):
+            return mode
+        try:
+            return SelectionMode(str(mode))
+        except ValueError:
+            return SelectionMode.RANDOM
+
+    @classmethod
+    def _build_streaks(
+        cls, histories: list[AssignmentHistory]
+    ) -> dict[int, tuple[str | None, int]]:
+        streaks: dict[int, tuple[str | None, int]] = {}
+        for history in sorted(histories, key=lambda item: item.created_at):
+            for entry in history.entries:
+                last_choice, count = streaks.get(entry.user_id, (None, 0))
+                if entry.choice == last_choice:
+                    streaks[entry.user_id] = (entry.choice, count + 1)
+                else:
+                    streaks[entry.user_id] = (entry.choice, 1)
+        return streaks
+
+    @classmethod
+    def _build_weight_map(
+        cls,
+        *,
+        members: list[discord.User],
+        choices: list[str],
+        streaks: dict[int, tuple[str | None, int]],
+    ) -> dict[int, dict[str, float]]:
+        weight_map: dict[int, dict[str, float]] = {}
+        for member in members:
+            last_choice, count = streaks.get(member.id, (None, 0))
+            member_weights: dict[str, float] = {}
+            for choice in choices:
+                if choice == last_choice and count > 0:
+                    member_weights[choice] = 1.0 / (count + 1)
+                else:
+                    member_weights[choice] = 1.0
+            weight_map[member.id] = member_weights
+        return weight_map
+
+    @classmethod
+    def _update_streaks_with_pairs(
+        cls,
+        streaks: dict[int, tuple[str | None, int]],
+        pairs: PairList,
+    ) -> dict[int, tuple[str | None, int]]:
+        updated = dict(streaks)
+        for pair in pairs.pairs:
+            last_choice, count = updated.get(pair.user.id, (None, 0))
+            if pair.choice == last_choice:
+                updated[pair.user.id] = (pair.choice, count + 1)
+            else:
+                updated[pair.user.id] = (pair.choice, 1)
+        return updated
+
+    @classmethod
+    def _detect_bias(
+        cls,
+        streaks: dict[int, tuple[str | None, int]],
+        *,
+        threshold: int,
+        members: list[discord.User],
+    ) -> list[tuple[str, str, int]]:
+        member_map = {member.id: member for member in members}
+        warnings: list[tuple[str, str, int]] = []
+        for user_id, (choice, count) in streaks.items():
+            if choice is None:
+                continue
+            if count > threshold:
+                member = member_map.get(user_id)
+                display_name = getattr(member, "display_name", str(user_id))
+                warnings.append((display_name, choice, count))
+        return warnings
+
     async def handle(
         self, context: CommandContext, services: Any
     ) -> FlowAction | Sequence[FlowAction]:
@@ -261,13 +341,77 @@ class MemberSelectedHandler(BaseStateHandler):
             raise ValueError("Template is not selected")
 
         choices = selected_template.choices
-        pairs = data_process.create_pair_from_list(selected_members, choices)
         db_manager = resolve_db_manager(context, services)
+        selection_mode_value = db_manager.get_selection_mode()
+        selection_mode = self._normalize_selection_mode(selection_mode_value)
+
+        current_guild = context.interaction.guild
+        guild_id = getattr(current_guild, "id", None) or getattr(
+            context.interaction, "guild_id", 0
+        )
+
+        history_records = db_manager.get_recent_history(
+            guild_id=guild_id,
+            template_title=selected_template.title,
+            limit=self.HISTORY_LOOKBACK,
+        )
+        streaks_before = self._build_streaks(history_records)
+        weights = None
+        if selection_mode is SelectionMode.BIAS_REDUCTION:
+            weights = self._build_weight_map(
+                members=selected_members, choices=choices, streaks=streaks_before
+            )
+
+        pairs = data_process.create_pair_from_list(
+            selected_members,
+            choices,
+            selection_mode=selection_mode,
+            weights=weights,
+        )
+
         embeds = data_process.create_embeds_from_pairs(
             pairs=pairs, mode=db_manager.get_embed_mode()
         )
 
-        return SendMessageAction(embeds=embeds, ephemeral=False)
+        db_manager.save_history(
+            guild_id=guild_id,
+            template=selected_template,
+            pairs=pairs,
+            selection_mode=selection_mode,
+        )
+
+        updated_streaks = self._update_streaks_with_pairs(streaks_before, pairs)
+        warnings = self._detect_bias(
+            updated_streaks,
+            threshold=self.CONSECUTIVE_THRESHOLD,
+            members=selected_members,
+        )
+
+        primary_action: FlowAction = SendMessageAction(
+            embeds=embeds, ephemeral=False
+        )
+
+        if not warnings:
+            return primary_action
+
+        warning_lines = [
+            f"• {name} は {choice} を {count} 回連続で担当しています"
+            for name, choice, count in warnings
+        ]
+        warning_text = "\n".join(warning_lines)
+        warning_embed = discord.Embed(
+            title="⚠️ 偏りを検知しました",
+            description=(
+                f"以下のメンバーが同じ役割を連続して担当しています。\n"
+                f"必要に応じて `/amidakuji` を再実行してください。\n\n{warning_text}"
+            ),
+            color=discord.Color.orange(),
+        )
+
+        return [
+            primary_action,
+            SendMessageAction(embed=warning_embed, ephemeral=True),
+        ]
 
 
 class CancelledHandler(BaseStateHandler):

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 
 import discord
@@ -52,6 +55,28 @@ class PairList:
 class ResultEmbedMode(Enum):
     COMPACT = "compact"
     DETAILED = "detailed"
+
+
+class SelectionMode(Enum):
+    RANDOM = "random"
+    BIAS_REDUCTION = "bias_reduction"
+
+
+@dataclass
+class AssignmentEntry:
+    user_id: int
+    user_name: str
+    choice: str
+
+
+@dataclass
+class AssignmentHistory:
+    guild_id: int
+    template_title: str
+    created_at: datetime
+    entries: list[AssignmentEntry]
+    choices: list[str] = field(default_factory=list)
+    selection_mode: SelectionMode = SelectionMode.RANDOM
 
 
 if __name__ == "__main__":

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -1,7 +1,10 @@
+import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import utils
 from db_manager import DBManager
+from models.model import Pair, PairList, SelectionMode, Template
 
 
 def test_get_embed_mode_initializes_missing_document():
@@ -13,6 +16,7 @@ def test_get_embed_mode_initializes_missing_document():
 
     manager.info_repository = mock_info_repository
     manager.user_repository = object()
+    manager.history_repository = MagicMock()
     manager.db = object()
 
     try:
@@ -36,6 +40,7 @@ def test_get_default_templates_initializes_when_missing_document():
 
     manager.info_repository = mock_info_repository
     manager.user_repository = object()
+    manager.history_repository = MagicMock()
     manager.db = object()
 
     try:
@@ -45,3 +50,96 @@ def test_get_default_templates_initializes_when_missing_document():
 
     assert templates == []
     mock_info_repository.create_document.assert_called_once()
+
+
+def test_get_selection_mode_initializes_missing_document():
+    utils.Singleton._instances.pop(DBManager, None)
+    manager = DBManager.get_instance()
+
+    mock_info_repository = MagicMock()
+    mock_info_repository.read_document.return_value = None
+
+    manager.info_repository = mock_info_repository
+    manager.user_repository = object()
+    manager.history_repository = MagicMock()
+    manager.db = object()
+
+    try:
+        mode = manager.get_selection_mode()
+    finally:
+        utils.Singleton._instances.pop(DBManager, None)
+
+    assert mode == SelectionMode.RANDOM.value
+    mock_info_repository.create_document.assert_called_once_with(
+        "selection_mode", {"selection_mode": SelectionMode.RANDOM.value}
+    )
+
+
+def test_save_history_uses_history_repository():
+    utils.Singleton._instances.pop(DBManager, None)
+    manager = DBManager.get_instance()
+
+    mock_history_repository = MagicMock()
+    manager.history_repository = mock_history_repository
+    manager.info_repository = MagicMock()
+    manager.user_repository = object()
+    manager.db = object()
+
+    template = Template(title="League", choices=["Top"])
+    user = SimpleNamespace(id=1, display_name="Tester", name="Tester")
+    pairs = PairList(pairs=[Pair(user=user, choice="Top")])
+
+    try:
+        manager.save_history(
+            guild_id=42,
+            template=template,
+            pairs=pairs,
+            selection_mode=SelectionMode.RANDOM,
+        )
+    finally:
+        utils.Singleton._instances.pop(DBManager, None)
+
+    mock_history_repository.add_entry.assert_called_once()
+    saved_data = mock_history_repository.add_entry.call_args.kwargs.get("data")
+    if saved_data is None:
+        saved_data = mock_history_repository.add_entry.call_args.args[0]
+    assert saved_data["guild_id"] == 42
+    assert saved_data["template_title"] == template.title
+    assert saved_data["selection_mode"] == SelectionMode.RANDOM.value
+    assert saved_data["entries"][0]["user_id"] == 1
+
+
+def test_get_recent_history_converts_documents():
+    utils.Singleton._instances.pop(DBManager, None)
+    manager = DBManager.get_instance()
+
+    timestamp = datetime.datetime.now(datetime.timezone.utc)
+    mock_history_repository = MagicMock()
+    mock_history_repository.fetch_recent.return_value = [
+        {
+            "guild_id": 1,
+            "template_title": "League",
+            "created_at": timestamp,
+            "entries": [
+                {"user_id": 1, "user_name": "Tester", "choice": "Top"}
+            ],
+            "choices": ["Top"],
+            "selection_mode": SelectionMode.RANDOM.value,
+        }
+    ]
+
+    manager.history_repository = mock_history_repository
+    manager.info_repository = MagicMock()
+    manager.user_repository = object()
+    manager.db = object()
+
+    try:
+        histories = manager.get_recent_history(guild_id=1)
+    finally:
+        utils.Singleton._instances.pop(DBManager, None)
+
+    assert len(histories) == 1
+    history = histories[0]
+    assert history.template_title == "League"
+    assert history.entries[0].choice == "Top"
+    assert history.created_at == timestamp


### PR DESCRIPTION
## Summary
- track amidakuji assignment history in Firestore via DBManager and expose selection mode configuration
- add bias-reduction weighting, streak analysis, and warning messaging to MemberSelectedHandler
- provide slash commands for toggling selection mode and viewing recent history with embeds
- extend unit tests for history logic, weighting, and data access

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce2a0bea9c832a9555790d75d431b8