### PR TITLE
Add startup self-check diagnostics

### DIFF
--- a/src/db_manager.py
+++ b/src/db_manager.py
@@ -28,6 +28,7 @@ from models.model import (
     AssignmentHistory,
     SelectionMode,
     Template,
+    TemplateScope,
     UserInfo,
 )
 

--- a/src/main.py
+++ b/src/main.py
@@ -17,8 +17,10 @@ from models.context_model import CommandContext
 from models.model import SelectionMode
 from models.state_model import AmidakujiState
 from services.app_context import create_db_manager
+from services.startup_check import StartupSelfCheck
 from utils import (
     DATEFORMAT,
+    ERROR,
     FORMAT,
     INFO,
     CommandsTranslator,
@@ -50,6 +52,13 @@ class Client(discord.Client):
     async def on_ready(self):
         # デフォルトテンプレートの初期化
         self.db._init_default_templates()
+
+        # 起動時セルフチェック
+        checker = StartupSelfCheck(self.db)
+        if not checker.run(discord_client=self):
+            logging.error(ERROR + "Critical startup check failed. Shutting down client.")
+            await self.close()
+            return
 
         # 以下ログ
         logging.info(

--- a/src/services/startup_check.py
+++ b/src/services/startup_check.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, List
+
+import discord
+
+from db_manager import DBManager
+from utils import ERROR, INFO, SUCCESS, WARN, green, red, yellow
+
+
+class CheckStatus(Enum):
+    """Represents the outcome of a startup self-check."""
+
+    OK = "ok"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(slots=True)
+class CheckResult:
+    """Detailed result for a single self-check item."""
+
+    name: str
+    status: CheckStatus
+    message: str
+
+
+class StartupSelfCheck:
+    """Run diagnostics required for safe bot execution."""
+
+    REQUIRED_COLLECTIONS: tuple[str, ...] = (
+        "users",
+        "info",
+        "shared_templates",
+        "history",
+    )
+
+    def __init__(self, db_manager: DBManager) -> None:
+        self._db_manager = db_manager
+
+    def run(self, *, discord_client: discord.Client) -> bool:
+        """Execute all self-checks and log their results."""
+
+        logging.info(INFO + "Running startup self-checks...")
+        results: List[CheckResult] = []
+
+        results.append(self._check_discord(discord_client))
+        results.append(self._check_firebase())
+        results.extend(self._check_collections(self.REQUIRED_COLLECTIONS))
+
+        for result in results:
+            if result.status is CheckStatus.OK:
+                logging.info(
+                    INFO
+                    + SUCCESS
+                    + f"[{result.name}] {green(result.message)}"
+                )
+            elif result.status is CheckStatus.WARNING:
+                logging.warning(
+                    WARN
+                    + f"[{result.name}] {yellow(result.message)}"
+                )
+            else:
+                logging.error(
+                    ERROR
+                    + f"[{result.name}] {red(result.message)}"
+                )
+
+        has_error = any(result.status is CheckStatus.ERROR for result in results)
+        if has_error:
+            logging.error(ERROR + "Startup self-check failed.")
+        else:
+            logging.info(INFO + SUCCESS + "Startup self-check completed without errors.")
+
+        return not has_error
+
+    def _check_discord(self, discord_client: discord.Client) -> CheckResult:
+        """Verify that the Discord client authenticated successfully."""
+
+        user = getattr(discord_client, "user", None)
+        if user is None:
+            return CheckResult(
+                name="discord_auth",
+                status=CheckStatus.ERROR,
+                message="Discord client user is not available. Authentication may have failed.",
+            )
+
+        return CheckResult(
+            name="discord_auth",
+            status=CheckStatus.OK,
+            message=f"Authenticated as {user} (id={user.id}).",
+        )
+
+    def _check_firebase(self) -> CheckResult:
+        """Confirm that the Firebase client is initialized and reachable."""
+
+        db = getattr(self._db_manager, "db", None)
+        if db is None:
+            return CheckResult(
+                name="firebase_auth",
+                status=CheckStatus.ERROR,
+                message="Firestore client is not initialized.",
+            )
+
+        try:
+            project_id = getattr(db, "project", "<unknown>")
+            next(db.collections(), None)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            return CheckResult(
+                name="firebase_auth",
+                status=CheckStatus.ERROR,
+                message=f"Failed to connect to Firestore: {exc}",
+            )
+
+        return CheckResult(
+            name="firebase_auth",
+            status=CheckStatus.OK,
+            message=f"Connected to Firestore project '{project_id}'.",
+        )
+
+    def _check_collections(self, collections: Iterable[str]) -> list[CheckResult]:
+        """Inspect required Firestore collections and ensure they are reachable."""
+
+        db = getattr(self._db_manager, "db", None)
+        if db is None:
+            return [
+                CheckResult(
+                    name="firestore_collections",
+                    status=CheckStatus.ERROR,
+                    message="Firestore client is not initialized.",
+                )
+            ]
+
+        results: list[CheckResult] = []
+        for collection_name in collections:
+            try:
+                has_document = next(
+                    db.collection(collection_name).limit(1).stream(),
+                    None,
+                )
+                if has_document is None:
+                    results.append(
+                        CheckResult(
+                            name=f"collection:{collection_name}",
+                            status=CheckStatus.WARNING,
+                            message="No documents found. Collection is accessible but currently empty.",
+                        )
+                    )
+                else:
+                    results.append(
+                        CheckResult(
+                            name=f"collection:{collection_name}",
+                            status=CheckStatus.OK,
+                            message="Collection is accessible and contains documents.",
+                        )
+                    )
+            except Exception as exc:  # pragma: no cover - defensive logging
+                results.append(
+                    CheckResult(
+                        name=f"collection:{collection_name}",
+                        status=CheckStatus.ERROR,
+                        message=f"Failed to access collection: {exc}",
+                    )
+                )
+
+        return results

--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -99,6 +99,7 @@ def test_get_user_includes_shared_and_public_templates():
     manager.user_repository = mock_user_repository
     manager.info_repository = mock_info_repository
     manager.shared_template_repository = mock_shared_repository
+    manager.history_repository = MagicMock()
     manager.db = object()
 
     try:
@@ -128,6 +129,7 @@ def test_copy_shared_template_to_user_generates_unique_title():
 
     manager.get_user = MagicMock(return_value=user)
     manager.add_custom_template = MagicMock()
+    manager.history_repository = MagicMock()
 
     shared_template = Template(
         title="Guild Shared",

--- a/tests/test_flow_handlers.py
+++ b/tests/test_flow_handlers.py
@@ -148,6 +148,7 @@ async def test_use_public_templates_handler_returns_select_view(base_interaction
     assert isinstance(action, SendViewAction)
     assert isinstance(action.view, PublicTemplateSelectView)
 
+@pytest.mark.asyncio
 async def test_option_name_entered_handler_updates_snapshot(base_interaction):
     context = CommandContext(
         interaction=base_interaction,
@@ -242,7 +243,7 @@ async def test_option_moved_down_handler_swaps_options(base_interaction):
     assert context.options_snapshot == ["Alpha", "Gamma", "Beta"]
     assert context.option_edit_index == 2
     assert isinstance(actions[1], SendMessageAction)
-    assert "Beta" in (actions[1].content or ""
+    assert "Beta" in (actions[1].content or "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a startup self-check service that validates Discord authentication, Firebase connectivity, and Firestore collections
- integrate the self-check into the Discord client startup flow and halt the bot if a critical check fails
- fix supporting imports and adjust tests to ensure asynchronous handlers and repository mocks are configured properly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ce573de538832a863fd0454f401428